### PR TITLE
Unifies time types

### DIFF
--- a/examples/hitsound-copier.rs
+++ b/examples/hitsound-copier.rs
@@ -8,7 +8,7 @@ use libosu::{
     beatmap::Beatmap,
     hitobject::{HitObjectKind, SliderInfo, SpinnerInfo},
     hitsounds::{Additions, SampleSet},
-    timing::TimestampMillis,
+    timing::Millis,
 };
 use structopt::StructOpt;
 
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
 
 #[derive(Debug)]
 struct HitsoundInfo {
-    time: TimestampMillis,
+    time: Millis,
     sample_set: SampleSet,
     additions_set: SampleSet,
     additions: Additions,
@@ -112,12 +112,12 @@ fn collect_hitsounds(beatmap: &Beatmap) -> Result<Vec<HitsoundInfo>> {
                         *addition_set
                     };
                     hitsounds.push(HitsoundInfo {
-                        time: TimestampMillis(time as i32),
+                        time: Millis(time as i32),
                         sample_set: edge_sample_set,
                         additions_set: edge_addition_set,
                         additions: *additions,
                     });
-                    time += duration;
+                    time += duration.0 as f64;
                 }
             }
             // spinners get 1 hitsound at the end
@@ -171,7 +171,7 @@ fn write_hitsounds(hitsounds: &Vec<HitsoundInfo>, beatmap: &mut Beatmap) -> Resu
             } else if let HitObjectKind::Slider(SliderInfo { num_repeats, .. }) = ho.kind {
                 let time_diff = (hitsound.time.0 - ho.start_time.0) as f64;
                 let duration = beatmap.get_slider_duration(ho).unwrap();
-                let num_repeats_approx = time_diff / duration;
+                let num_repeats_approx = time_diff / duration.0 as f64;
                 let num_repeats_rounded = num_repeats_approx.round();
                 if num_repeats_rounded as u32 > num_repeats {
                     continue;

--- a/examples/hitsound-copier.rs
+++ b/examples/hitsound-copier.rs
@@ -117,7 +117,7 @@ fn collect_hitsounds(beatmap: &Beatmap) -> Result<Vec<HitsoundInfo>> {
                         additions_set: edge_addition_set,
                         additions: *additions,
                     });
-                    time += duration.0 as f64;
+                    time += duration;
                 }
             }
             // spinners get 1 hitsound at the end
@@ -171,7 +171,7 @@ fn write_hitsounds(hitsounds: &Vec<HitsoundInfo>, beatmap: &mut Beatmap) -> Resu
             } else if let HitObjectKind::Slider(SliderInfo { num_repeats, .. }) = ho.kind {
                 let time_diff = (hitsound.time.0 - ho.start_time.0) as f64;
                 let duration = beatmap.get_slider_duration(ho).unwrap();
-                let num_repeats_approx = time_diff / duration.0 as f64;
+                let num_repeats_approx = time_diff / duration;
                 let num_repeats_rounded = num_repeats_approx.round();
                 if num_repeats_rounded as u32 > num_repeats {
                     continue;

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -16,14 +16,14 @@ impl Beatmap {
             HitObjectKind::Circle => Some(ho.start_time),
             HitObjectKind::Slider(_) => {
                 let duration = self.get_slider_duration(ho)?;
-                Some(Millis(ho.start_time.0 + duration.0))
+                Some(Millis(ho.start_time.0 + duration as i32))
             }
             HitObjectKind::Spinner(SpinnerInfo { end_time }) => Some(end_time),
         }
     }
 
     /// Returns the slider duration for a given slider
-    pub fn get_slider_duration(&self, ho: &HitObject) -> Option<Millis> {
+    pub fn get_slider_duration(&self, ho: &HitObject) -> Option<f64> {
         let info = match &ho.kind {
             HitObjectKind::Slider(info) => info,
             _ => return None,
@@ -38,7 +38,7 @@ impl Beatmap {
         let beat_duration = 60_000.0 / bpm;
         let duration = beats_number * beat_duration;
 
-        Some(Millis(duration as i32))
+        Some(duration)
     }
 
     /// Returns the slider velocity at the given time

--- a/src/beatmap/ext.rs
+++ b/src/beatmap/ext.rs
@@ -1,7 +1,7 @@
 use crate::beatmap::Beatmap;
 use crate::hitobject::{HitObject, HitObjectKind, SpinnerInfo};
 use crate::timing::{
-    InheritedTimingInfo, TimestampMillis, TimingPoint, TimingPointKind, UninheritedTimingInfo,
+    InheritedTimingInfo, Millis, TimingPoint, TimingPointKind, UninheritedTimingInfo,
 };
 
 impl Beatmap {
@@ -11,19 +11,19 @@ impl Beatmap {
     }
 
     /// Computes the end time of the given hitobject
-    pub fn get_hitobject_end_time(&self, ho: &HitObject) -> Option<TimestampMillis> {
+    pub fn get_hitobject_end_time(&self, ho: &HitObject) -> Option<Millis> {
         match ho.kind {
             HitObjectKind::Circle => Some(ho.start_time),
             HitObjectKind::Slider(_) => {
                 let duration = self.get_slider_duration(ho)?;
-                Some(TimestampMillis(ho.start_time.0 + duration as i32))
+                Some(Millis(ho.start_time.0 + duration.0))
             }
             HitObjectKind::Spinner(SpinnerInfo { end_time }) => Some(end_time),
         }
     }
 
     /// Returns the slider duration for a given slider
-    pub fn get_slider_duration(&self, ho: &HitObject) -> Option<f64> {
+    pub fn get_slider_duration(&self, ho: &HitObject) -> Option<Millis> {
         let info = match &ho.kind {
             HitObjectKind::Slider(info) => info,
             _ => return None,
@@ -38,11 +38,11 @@ impl Beatmap {
         let beat_duration = 60_000.0 / bpm;
         let duration = beats_number * beat_duration;
 
-        Some(duration)
+        Some(Millis(duration as i32))
     }
 
     /// Returns the slider velocity at the given time
-    pub fn get_slider_velocity_at_time(&self, time: TimestampMillis) -> f64 {
+    pub fn get_slider_velocity_at_time(&self, time: Millis) -> f64 {
         // TODO: replace this with binary search
         let mut current = 1.0;
 
@@ -68,7 +68,7 @@ impl Beatmap {
     }
 
     /// Returns the BPM at the given time
-    pub fn get_bpm_at_time(&self, time: TimestampMillis) -> Option<f64> {
+    pub fn get_bpm_at_time(&self, time: Millis) -> Option<f64> {
         // TODO: replace this with binary search
         let mut current = None;
 
@@ -79,7 +79,7 @@ impl Beatmap {
             }
 
             if let TimingPointKind::Uninherited(UninheritedTimingInfo { mpb, .. }) = tp.kind {
-                current = Some(60_000.0 / mpb);
+                current = Some(60_000.0 / mpb.0 as f64);
             }
         }
 

--- a/src/beatmap/format.rs
+++ b/src/beatmap/format.rs
@@ -5,13 +5,13 @@ use std::str::FromStr;
 use num::FromPrimitive;
 use regex::Regex;
 
-use crate::color::Color;
 use crate::enums::{GridSize, Mode};
 use crate::errors::ParseError;
 use crate::events::Event;
 use crate::hitobject::HitObject;
 use crate::hitsounds::SampleSet;
 use crate::timing::TimingPoint;
+use crate::{color::Color, timing::Millis};
 
 use super::Beatmap;
 
@@ -152,10 +152,14 @@ impl Beatmap {
                                 kvalue!(line_no, captures[beatmap.audio_filename]: str)
                             }
                             "AudioLeadIn" => {
-                                kvalue!(line_no, captures[beatmap.audio_leadin]: parse(u32))
+                                let ms =
+                                    kvalue!(line_no, captures[beatmap.audio_leadin] => parse(i32));
+                                beatmap.audio_leadin = Millis(ms);
                             }
                             "PreviewTime" => {
-                                kvalue!(line_no, captures[beatmap.preview_time]: parse(u32))
+                                let ms =
+                                    kvalue!(line_no, captures[beatmap.preview_time] => parse(i32));
+                                beatmap.preview_time = Millis(ms);
                             }
                             "Countdown" => {
                                 kvalue!(line_no, captures[beatmap.countdown]: parse(bool))
@@ -344,8 +348,8 @@ impl fmt::Display for Beatmap {
         // general
         writeln!(f, "[General]")?;
         writeln!(f, "AudioFilename: {}", self.audio_filename)?;
-        writeln!(f, "AudioLeadIn: {}", self.audio_leadin)?;
-        writeln!(f, "PreviewTime: {}", self.preview_time)?;
+        writeln!(f, "AudioLeadIn: {}", self.audio_leadin.0)?;
+        writeln!(f, "PreviewTime: {}", self.preview_time.0)?;
         writeln!(f, "Countdown: {}", if self.countdown { 1 } else { 0 })?;
         writeln!(
             f,

--- a/src/beatmap/mod.rs
+++ b/src/beatmap/mod.rs
@@ -6,7 +6,7 @@ use crate::enums::{GridSize, Mode};
 use crate::events::Event;
 use crate::hitobject::{HitObject, HitObjectKind};
 use crate::hitsounds::SampleSet;
-use crate::timing::{TimestampMillis, TimingPoint};
+use crate::timing::{Millis, TimingPoint};
 
 pub use self::format::*;
 
@@ -60,14 +60,14 @@ impl Difficulty {
     /// - AR > 5: preempt = 1200ms - 750ms * (AR - 5) / 5
     ///
     /// [1]: https://osu.ppy.sh/wiki/en/Beatmapping/Approach_rate
-    pub fn approach_preempt(&self) -> u32 {
-        if self.approach_rate < 5.0 {
-            1200 + (600.0 * (5.0 - self.approach_rate)) as u32 / 5
+    pub fn approach_preempt(&self) -> Millis {
+        Millis(if self.approach_rate < 5.0 {
+            1200 + (600.0 * (5.0 - self.approach_rate)) as i32 / 5
         } else if self.approach_rate > 5.0 {
-            1200 - (750.0 * (self.approach_rate - 5.0)) as u32 / 5
+            1200 - (750.0 * (self.approach_rate - 5.0)) as i32 / 5
         } else {
             1200
-        }
+        })
     }
 
     /// Calculates the duration of time (in milliseconds) it takes the hitobject to fade in
@@ -80,14 +80,14 @@ impl Difficulty {
     /// - AR > 5: fade_in = 800ms - 500ms * (AR - 5) / 5
     ///
     /// [1]: https://osu.ppy.sh/wiki/en/Beatmapping/Approach_rate
-    pub fn approach_fade_time(&self) -> u32 {
-        if self.approach_rate < 5.0 {
-            800 + (400.0 * (5.0 - self.approach_rate)) as u32 / 5
+    pub fn approach_fade_time(&self) -> Millis {
+        Millis(if self.approach_rate < 5.0 {
+            800 + (400.0 * (5.0 - self.approach_rate)) as i32 / 5
         } else if self.approach_rate > 5.0 {
-            800 - (500.0 * (self.approach_rate - 5.0)) as u32 / 5
+            800 - (500.0 * (self.approach_rate - 5.0)) as i32 / 5
         } else {
             800
-        }
+        })
     }
 }
 
@@ -102,10 +102,10 @@ pub struct Beatmap {
     pub audio_filename: String,
 
     /// The amount of time (in milliseconds) added before the audio file begins playing. Useful for audio files that begin immediately.
-    pub audio_leadin: u32,
+    pub audio_leadin: Millis,
 
     /// When (in milliseconds) the audio file should begin playing when selected in the song selection menu.
-    pub preview_time: u32,
+    pub preview_time: Millis,
 
     /// Whether or not to show the countdown
     pub countdown: bool,
@@ -192,8 +192,8 @@ impl Default for Beatmap {
             version: 0,
 
             audio_filename: String::new(),
-            audio_leadin: 0,
-            preview_time: 0,
+            audio_leadin: Millis(0),
+            preview_time: Millis(0),
             countdown: false,
             sample_set: SampleSet::None,
             stack_leniency: 0.7,
@@ -230,7 +230,7 @@ impl Default for Beatmap {
 
 impl Beatmap {
     /// Returns the timing point associated with the timing section to which the given time belongs.
-    pub fn locate_timing_point(&self, time: impl Into<TimestampMillis>) -> Option<TimingPoint> {
+    pub fn locate_timing_point(&self, time: impl Into<Millis>) -> Option<TimingPoint> {
         // TODO: make this efficient
         let mut tp = None;
         let time = time.into();
@@ -243,7 +243,7 @@ impl Beatmap {
     }
 
     /// Returns the hitobject located at the given time.
-    pub fn locate_hitobject(&self, time: impl Into<TimestampMillis>) -> Option<HitObject> {
+    pub fn locate_hitobject(&self, time: impl Into<Millis>) -> Option<HitObject> {
         let time = time.into();
         for hit_object in self.hit_objects.iter() {
             if hit_object.start_time == time {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use crate::enums::{Grade, Mode, Mods, RankedStatus};
+use crate::{enums::{Grade, Mode, Mods, RankedStatus}, timing::Millis};
 
 pub use self::binary::{Error, ReadBytesOsu, WriteBytesOsu};
 
@@ -99,12 +99,12 @@ pub struct DbBeatmap {
     /// A list of calculated star ratings for different mods for mania. Empty if version less than 20140609.
     pub std_mania_rating: Vec<(Mods, f64)>,
 
-    /// The drain time in seconds.
-    pub drain_time: u32,
+    /// The drain time in milliseconds.
+    pub drain_time: Millis,
     /// The total time in milliseconds.
-    pub total_time: u32,
+    pub total_time: Millis,
     /// The preview time point in milliseconds.
-    pub preview_time: u32,
+    pub preview_time: Millis,
 
     /// Timing points for the beatmap.
     pub timing_points: Vec<DbBeatmapTimingPoint>,
@@ -276,9 +276,9 @@ impl DbBeatmap {
             std_taiko_rating: Self::read_star_rating(&mut reader)?,
             std_ctb_rating: Self::read_star_rating(&mut reader)?,
             std_mania_rating: Self::read_star_rating(&mut reader)?,
-            drain_time: reader.read_u32::<LittleEndian>()?,
-            total_time: reader.read_u32::<LittleEndian>()?,
-            preview_time: reader.read_u32::<LittleEndian>()?,
+            drain_time: Millis(reader.read_i32::<LittleEndian>()? * 1000), // the file contains seconds, not milliseconds
+            total_time: Millis(reader.read_i32::<LittleEndian>()?),
+            preview_time: Millis(reader.read_i32::<LittleEndian>()?),
             timing_points: Self::read_timing_points(&mut reader)?,
             beatmap_id: reader.read_u32::<LittleEndian>()?,
             beatmap_set_id: reader.read_u32::<LittleEndian>()?,
@@ -346,7 +346,7 @@ impl Db {
 mod tests {
     use std::io::BufReader;
 
-    use crate::enums::{Grade, Mode, Mods, RankedStatus, UserPermission};
+    use crate::{enums::{Grade, Mode, Mods, RankedStatus, UserPermission}, timing::Millis};
 
     use super::{Db, DbBeatmap, DbBeatmapTimingPoint};
 
@@ -427,9 +427,9 @@ mod tests {
         ],
         std_ctb_rating: vec![],
         std_mania_rating: vec![],
-        drain_time: 31,
-        total_time: 34109,
-        preview_time: 5,
+        drain_time: Millis(31000),
+        total_time: Millis(34109),
+        preview_time: Millis(5),
         timing_points: vec![
             DbBeatmapTimingPoint {
                 bpm: 566.037735849057,

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use crate::errors::ParseError;
 use crate::math::Point;
-use crate::timing::TimestampMillis;
+use crate::timing::Millis;
 
 /// Beatmap event
 #[non_exhaustive]
@@ -40,7 +40,7 @@ pub struct BackgroundEvent {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VideoEvent {
     /// The timestamp at which the video starts
-    pub start_time: TimestampMillis,
+    pub start_time: Millis,
 
     /// Location of the background image relative to the beatmap directory.
     pub filename: String,
@@ -54,10 +54,10 @@ pub struct VideoEvent {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BreakEvent {
     /// The timestamp at which the break starts
-    pub start_time: TimestampMillis,
+    pub start_time: Millis,
 
     /// The timestamp at which the break ends
-    pub end_time: TimestampMillis,
+    pub end_time: Millis,
 }
 
 impl FromStr for Event {
@@ -89,7 +89,7 @@ impl FromStr for Event {
                     Point::new(0, 0)
                 };
                 Event::Video(VideoEvent {
-                    start_time: TimestampMillis(start_time),
+                    start_time: Millis(start_time),
                     filename,
                     offset,
                 })
@@ -98,8 +98,8 @@ impl FromStr for Event {
                 let start_time = parts[1].parse::<i32>()?;
                 let end_time = parts[2].parse::<i32>()?;
                 Event::Break(BreakEvent {
-                    start_time: TimestampMillis(start_time),
-                    end_time: TimestampMillis(end_time),
+                    start_time: Millis(start_time),
+                    end_time: Millis(end_time),
                 })
             }
             _ => Event::Storyboard(line.to_string()),
@@ -118,9 +118,9 @@ impl fmt::Display for Event {
             Event::Video(evt) => write!(
                 f,
                 "1,{},{:?},{},{}",
-                evt.start_time, evt.filename, evt.offset.x, evt.offset.y
+                evt.start_time.0, evt.filename, evt.offset.x, evt.offset.y
             )?,
-            Event::Break(evt) => write!(f, "2,{},{}", evt.start_time, evt.end_time)?,
+            Event::Break(evt) => write!(f, "2,{},{}", evt.start_time.0, evt.end_time.0)?,
             Event::Storyboard(line) => write!(f, "{}", line)?,
         }
 

--- a/src/hitobject.rs
+++ b/src/hitobject.rs
@@ -8,7 +8,7 @@ use crate::errors::{ParseError, ParseResult};
 use crate::hitsounds::{Additions, SampleInfo, SampleSet};
 use crate::math::Point;
 use crate::spline::Spline;
-use crate::timing::TimestampMillis;
+use crate::timing::Millis;
 
 /// Distinguishes between different types of slider splines.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -70,7 +70,7 @@ pub struct SliderInfo {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpinnerInfo {
     /// The time at which the slider ends.
-    pub end_time: TimestampMillis,
+    pub end_time: Millis,
 }
 
 /// Distinguishes between different types of hit objects.
@@ -112,7 +112,7 @@ pub struct HitObject {
     pub pos: Point<i32>,
 
     /// When this hit object occurs during the map.
-    pub start_time: TimestampMillis,
+    pub start_time: Millis,
 
     /// The kind of HitObject this represents (circle, slider, spinner).
     pub kind: HitObjectKind,
@@ -188,7 +188,7 @@ impl FromStr for HitObject {
         let additions = Additions::from_bits(additions_bits)
             .ok_or(ParseError::InvalidAdditions(additions_bits))?;
 
-        let start_time = TimestampMillis(timestamp);
+        let start_time = Millis(timestamp);
 
         // color is the top 3 bits of the "type" string, since there's a possible of 8 different
         // combo colors max
@@ -284,7 +284,7 @@ impl FromStr for HitObject {
                     SampleInfo::default()
                 };
                 HitObjectKind::Spinner(SpinnerInfo {
-                    end_time: TimestampMillis(end_time),
+                    end_time: Millis(end_time),
                 })
             }
             o => {
@@ -354,7 +354,7 @@ impl fmt::Display for HitObject {
             }
 
             HitObjectKind::Spinner(info) => {
-                write!(f, ",{}", info.end_time)?;
+                write!(f, ",{}", info.end_time.0)?;
             }
         }
 

--- a/src/replay/actions.rs
+++ b/src/replay/actions.rs
@@ -78,6 +78,7 @@ impl ReplayActionData {
             .filter(|action_str| !action_str.trim().is_empty())
             .map(|action_str| {
                 let mut parts = action_str.split('|');
+                println!("{:?}", parts);
                 let time = Millis(parts.next().unwrap().parse::<i32>()?);
                 let x = parts.next().unwrap().parse::<f32>()?;
                 let y = parts.next().unwrap().parse::<f32>()?;
@@ -98,7 +99,13 @@ impl ReplayActionData {
             })
             .collect::<ReplayResult<Vec<_>>>()?;
 
-        let has_seed = matches!(frames.last(), Some(ReplayAction { time: Millis(-12345), .. }));
+        let has_seed = matches!(
+            frames.last(),
+            Some(ReplayAction {
+                time: Millis(-12345),
+                ..
+            })
+        );
         let rng_seed = if has_seed {
             let last_element = frames.pop().expect("has_seed checked");
             Some(last_element.buttons.bits())

--- a/src/replay/mod.rs
+++ b/src/replay/mod.rs
@@ -344,7 +344,7 @@ impl Replay {
 
                 let this_frame = format!(
                     "{}|{}|{}|{}",
-                    frame.time,
+                    frame.time.0,
                     frame.x,
                     frame.y,
                     frame.buttons.bits()

--- a/src/replay/mod.rs
+++ b/src/replay/mod.rs
@@ -221,12 +221,12 @@ impl Replay {
         let mods = Mods::from_bits(mods_value).ok_or(ReplayError::UnexpectedMods(mods_value))?;
         let life_graph = reader
             .read_uleb128_string()?
-            .split(",")
+            .split(',')
             .filter_map(|frame| {
                 if frame.is_empty() {
                     None
                 } else {
-                    Some(frame.split("|"))
+                    Some(frame.split('|'))
                 }
             })
             .map(|mut frame| {

--- a/src/timing/mod.rs
+++ b/src/timing/mod.rs
@@ -1,85 +1,41 @@
 mod point;
 
-use std::fmt;
-use std::ops::{Add, Div, Mul, Sub};
-
-use ordered_float::NotNan;
+use std::{
+    fmt,
+    ops::{Add, Deref},
+};
 
 pub use self::point::*;
 
 /// A struct representing a location in time as milliseconds (i32)
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TimestampMillis(pub i32);
+pub struct Millis(pub i32);
 
-impl TimestampMillis {
-    /// Convert the timestamp to seconds
-    pub fn as_seconds(&self) -> TimestampSec {
-        TimestampSec(unsafe { NotNan::unchecked_new(self.0 as f64 / 1000.0) })
-    }
-}
-
-impl fmt::Display for TimestampMillis {
+impl fmt::Display for Millis {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        f.write_fmt(format_args!("{}ms", self.0))
     }
 }
 
-/// A struct representing a location in time as seconds (f64)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TimestampSec(pub NotNan<f64>);
-
-impl TimestampSec {
-    /// Convert the timestamp to milliseconds
-    pub fn as_millis(&self) -> TimestampMillis {
-        TimestampMillis((self.0.into_inner() * 1000.0) as i32)
-    }
-
-    /// Create a new TimestampSec unsafely
-    pub fn unsafe_new(time: f64) -> Self {
-        TimestampSec(unsafe { NotNan::unchecked_new(time) })
+impl From<i32> for Millis {
+    fn from(v: i32) -> Self {
+        Self(v)
     }
 }
 
-impl fmt::Display for TimestampSec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+impl Deref for Millis {
+    type Target = i32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
-impl Add<Duration> for TimestampSec {
-    type Output = TimestampSec;
+impl Add<Millis> for Millis {
+    type Output = Millis;
 
-    fn add(self, other: Duration) -> Self::Output {
-        TimestampSec(self.0 + other.0)
-    }
-}
-
-impl Sub for TimestampSec {
-    type Output = Duration;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Duration(self.0 - other.0)
-    }
-}
-
-/// Duration of time
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Add, Sub)]
-pub struct Duration(pub NotNan<f64>);
-
-impl Mul<f64> for Duration {
-    type Output = Duration;
-
-    fn mul(self, rhs: f64) -> Self::Output {
-        Duration(self.0 * rhs)
-    }
-}
-
-impl Div<f64> for Duration {
-    type Output = Duration;
-
-    fn div(self, rhs: f64) -> Self::Output {
-        Duration(self.0 / rhs)
+    fn add(self, rhs: Millis) -> Self::Output {
+        Millis(self.0 + rhs.0)
     }
 }

--- a/tests/test_replays.rs
+++ b/tests/test_replays.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use libosu::{
     enums::{Mode, Mods},
     replay::{Buttons, Replay, ReplayActionData},
+    timing::Millis,
 };
 
 #[cfg(feature = "replay-data")]
@@ -167,12 +168,12 @@ fn test_replay_action_parser() -> Result<()> {
 
     assert_eq!(actions.len(), 2);
 
-    assert_eq!(actions[0].time, 1);
+    assert_eq!(actions[0].time, Millis(1));
     assert_eq!(actions[0].x, 32.1);
     assert_eq!(actions[0].y, 300.734);
     assert_eq!(actions[0].buttons, Buttons::empty());
 
-    assert_eq!(actions[1].time, 32);
+    assert_eq!(actions[1].time, Millis(32));
     assert_eq!(actions[1].x, 500.5123);
     assert_eq!(actions[1].y, 0.0);
     assert_eq!(actions[1].buttons, Buttons::K2 | Buttons::M2);

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -9,7 +9,7 @@ use libosu::{
     events::{BackgroundEvent, BreakEvent, Event},
     hitsounds::SampleSet,
     math::Point,
-    timing::TimestampMillis,
+    timing::Millis,
 };
 
 fn load_beatmap(path: impl AsRef<Path>) -> Beatmap {
@@ -25,8 +25,8 @@ fn parse_taeyang_remote_control() {
     let beatmap = load_beatmap("tests/files/774965.osu");
 
     assert_eq!(beatmap.audio_filename, "control.mp3");
-    assert_eq!(beatmap.audio_leadin, 1000);
-    assert_eq!(beatmap.preview_time, 85495);
+    assert_eq!(beatmap.audio_leadin, Millis(1000));
+    assert_eq!(beatmap.preview_time, Millis(85495));
     assert_eq!(beatmap.countdown, false);
     assert_eq!(beatmap.sample_set, SampleSet::Normal);
     assert_eq!(beatmap.stack_leniency, 0.8);
@@ -67,8 +67,8 @@ fn parse_taeyang_remote_control() {
                 offset: Point::new(0, 0)
             }),
             Event::Break(BreakEvent {
-                start_time: TimestampMillis(184604),
-                end_time: TimestampMillis(189653),
+                start_time: Millis(184604),
+                end_time: Millis(189653),
             })
         ]
     );


### PR DESCRIPTION
I implemented the i32-only time typing I talked about, the only thing that lost precision here is `get_slider_duration` but I doubt that it has any real effect, worst case scenario we can add a second function returning float.
Closes #7