### PR TITLE
Remove debug println!() statements

### DIFF
--- a/src/replay/actions.rs
+++ b/src/replay/actions.rs
@@ -81,7 +81,6 @@ impl ReplayActionData {
             .filter(|action_str| !action_str.trim().is_empty())
             .map(|action_str| {
                 let mut parts = action_str.split('|');
-                println!("{:?}", parts);
                 let time = Millis(parts.next().unwrap().parse::<i32>()?);
                 let x = parts.next().unwrap().parse::<f32>()?;
                 let y = parts.next().unwrap().parse::<f32>()?;

--- a/src/timing/point.rs
+++ b/src/timing/point.rs
@@ -90,8 +90,6 @@ impl FromStr for TimingPoint {
         let input = input.trim_end_matches(',');
         let parts = input.split(',').collect::<Vec<_>>();
 
-        println!("PARTS {:?}", parts);
-
         if parts.len() < 2 {
             return Err(ParseError::InvalidTimingPoint(
                 "timing point must have more than 2 components",


### PR DESCRIPTION
Parsing a beatmap with libosu would cause the console window to be spammed with with debug prints. This PR removes those prints.